### PR TITLE
Make source location optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,14 @@
       - [Message attributes](#message-attributes)
       - [Example](#example-2)
 - [Changelog](#changelog)
+  - [v1.4.1](#v141)
   - [v1.4](#v14)
   - [v1.3](#v13)
   - [v1.2](#v12)
   - [v1.1](#v11)
 
 # AppMap data specification
+
 The AppMap data specification outlines a standard JSON data format that contains
 detailed information of an application's runtime code execution, data snapshots
 and metadata. This data can be used to generate analytics and visualizations of
@@ -295,8 +297,8 @@ Each "call" event has the following attributes:
 * **method_id** *Required* name of the function which was called in this event. Example: "show".
 * **path** *Recommended* path name of the file which triggered the event. Example: "/src/architecture/lib/appland/local/client.rb".
 * **lineno** *Recommended* line number which triggered the event. Example: 5.
-* **receiver** *Required* parameter object describing the object on which the function is called. Corresponds to the `receiver`, `self` and `this` concept found in various programming languages.
-* **parameters** *Required* array of parameter objects describing the function call parameters.
+* **receiver** *Optional* parameter object describing the object on which the function is called. Corresponds to the `receiver`, `self` and `this` concept found in various programming languages.
+* **parameters** *Recommended* array of parameter objects describing the function call parameters.
 * **static** *Required* flag if the method is class-scoped (static) or instance-scoped. Must be `true` or `false`. Example: true.
 
 #### Parameter object format
@@ -472,6 +474,8 @@ is a list of objects in [parameter object format](#parameter-object-format).
 ## v1.4.1
 
 * Make source location optional; it's not always possible to provide it but appmaps lacking it can still be useful.
+* Make receiver and parameters optional; they not always make sense and there could be performance
+  or operational reasons to skip capture.
 
 ## v1.4
 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Each "package" and "class" has the following attributes:
 
 Each "function" has the following attributes:
 
-* **location** *Required* File path and line number, separated by a colon. Example: "/Users/alice/src/myapp/lib/myapp/main.rb:5".
+* **location** *Recommended* File path and line number, separated by a colon. Example: "/Users/alice/src/myapp/lib/myapp/main.rb:5".
 * **static** *Required* flag if the method is class-scoped (static) or instance-scoped. Must be `true` or `false`. Example: true.
 * **labels** *Optional* list of arbitrary labels describing the function.
 * **comment** *Optional* documentation comment for the function extracted from the source code.
@@ -293,8 +293,8 @@ Each "call" event has the following attributes:
 
 * **defined_class** *Required* name of the class which defines the method. Example: "MyApp::User".
 * **method_id** *Required* name of the function which was called in this event. Example: "show".
-* **path** *Required* path name of the file which triggered the event. Example: "/src/architecture/lib/appland/local/client.rb".
-* **lineno** *Required* line number which triggered the event. Example: 5.
+* **path** *Recommended* path name of the file which triggered the event. Example: "/src/architecture/lib/appland/local/client.rb".
+* **lineno** *Recommended* line number which triggered the event. Example: 5.
 * **receiver** *Required* parameter object describing the object on which the function is called. Corresponds to the `receiver`, `self` and `this` concept found in various programming languages.
 * **parameters** *Required* array of parameter objects describing the function call parameters.
 * **static** *Required* flag if the method is class-scoped (static) or instance-scoped. Must be `true` or `false`. Example: true.
@@ -468,6 +468,10 @@ is a list of objects in [parameter object format](#parameter-object-format).
 ```
 
 # Changelog
+
+## v1.4.1
+
+* Make source location optional; it's not always possible to provide it but appmaps lacking it can still be useful.
 
 ## v1.4
 


### PR DESCRIPTION
It's not always possible to provide the source location, especially when tracing compiled (Java or .NET) code. However, appmaps lacking it can still be useful. `appmap-java` already omits this information when it's not available.
(I've used 'recommended' instead of 'optional' in line with RFC 2119 -- should we uppercase them and/or use the more familiar MUST/SHOULD/MAY?)

(Aside: should we also make `receiver` and `parameters` optional, seeing as the return value already is?)