### PR TITLE
Relax requirements on parameter objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,9 +317,9 @@ In order to correlate function call events with function objects defined in the 
 
 Each parameter is an object containing the following attributes:
 
-* **name** *Required* name of the parameter. Example: "login".
-* **object_id** *Required* unique id of the object. Example: 70340693307040
-* **class** *Required* fully qualified class name of the object. Example: "MyApp::User".
+* **name** *Recommended* name of the parameter. Example: "login".
+* **object_id** *Recommended* unique id of the object. Example: 70340693307040
+* **class** *Required* fully qualified class or type name of the object. Example: "MyApp::User".
 * **value** *Required* string describing the object. This is not a strict JSON serialization, but rather a display
   string which is intended for the user. These strings should be trimmed in length to 100 characters. Example: "MyApp
   user 'alice'"
@@ -508,6 +508,7 @@ is a list of objects in [parameter object format](#parameter-object-format). `me
 
 * Add optional `test_status` and `exception` fields in metadata for conveying the test status.
 * Add HTTP request and response headers, as implemented by appmap-ruby.
+* Relax requirements on parameter objects.
 
 ## v1.5.1
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@
       - [Message `call` attributes](#message-call-attributes)
       - [Example](#example-2)
 - [Changelog](#changelog)
+  - [v1.6.0](#v160)
+  - [v1.5.1](#v151)
   - [v1.5.0](#v150)
   - [v1.4.1](#v141)
   - [v1.4.0](#v140)
@@ -504,7 +506,8 @@ is a list of objects in [parameter object format](#parameter-object-format). `me
 ```
 
 # Changelog
-## Unreleased
+
+## v1.6.0
 
 * Add optional `test_status` and `exception` fields in metadata for conveying the test status.
 * Add HTTP request and response headers, as implemented by appmap-ruby.


### PR DESCRIPTION
- Change **name** from *required* to *recommended*. Rationale: in some languages, environments or circumstances reflecting a function signature is impossible (for example with python's built-ins). However it can still be possible to capture the argument tuple.
- Change **object_id** from *required* to *recommended*. Rationale: makes no useful sense for primitive values, such as integers; arguably also strings. Pretty much only useful with referenced objects, where it's useful to track object identity.
- Clarify that **class** can also be a type name (in many languages not every type is a class, even if it has classes).