### PR TITLE
explicit the continuous indexing constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ return from a function call which occurred during an actual program execution.
 
 Each event object has the following attributes:
 
-* **id** *Required* unique identifier. Example: 23522.
+* **id** *Required* per-thread unique and continuous identifier. In more detail, each thread should feature a continuous list of event ids starting at 1. That is that the id of the first event of the thread should be `1`, the id of the second event of the thread should be `2`, etc... So an event id is duplicate information of its position in the thread. Example: 23522.
 * **event** *Required* event type. Must be "call" or "return".
 * **thread_id** *Required* identifier of the execution thread. Example: 70340688724000.
 


### PR DESCRIPTION
I choose the indicate a rather stringent constraint where indexing should not only be monotonous but also continuous. This simplifies the corresponding validation in: https://www.npmjs.com/package/@appland/appmap-validate.